### PR TITLE
fix: set tag_prefix to empty to avoid invalid semantic version tag

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -22,6 +22,7 @@ jobs:
         with:
           custom_tag: "${{ needs.test.outputs.tag }}"
           github_token: "${{ secrets.GITHUB_TOKEN }}"
+          tag_prefix: ""
 
   goreleaser:
     name: Create release


### PR DESCRIPTION
The Github Action which creates tags prepends the tag value with `v` by default. As we add `v` to the tag when we generate it, we should set `tag_prefix` to an empty string to avoid getting an invalid tag