### PR TITLE
docs: fix markdown for import statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Go implementation of the [draft HTTP Message Signatures RFC](https://www.ietf.or
 
 ## Usage
 
-`import "github.com/form3tech-oss/go-http-message-signatures"
+```go
+import "github.com/form3tech-oss/go-http-message-signatures"
+```
 
 ### Signing
 


### PR DESCRIPTION
embedded code in the "Usage" section is not terminated with **`** and therefore isn't rendered as intended